### PR TITLE
add compact styles.

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -329,7 +329,7 @@ func (enc *TableEncoder) divider(w io.Writer, r [4]rune) error {
 	b, hasIndicator := enc.getBorders(r)
 
 	// left
-	if _, err = w.Write([]byte(b[0])); err != nil {
+	if _, err = w.Write(b[0]); err != nil {
 		return err
 	}
 
@@ -348,14 +348,14 @@ func (enc *TableEncoder) divider(w io.Writer, r [4]rune) error {
 
 		// middle separator
 		if i != len(enc.maxWidths)-1 {
-			if _, err = w.Write([]byte(b[1])); err != nil {
+			if _, err = w.Write(b[1]); err != nil {
 				return err
 			}
 		}
 	}
 
 	// right
-	if _, err = w.Write([]byte(b[2])); err != nil {
+	if _, err = w.Write(b[2]); err != nil {
 		return err
 	}
 

--- a/opts.go
+++ b/opts.go
@@ -54,6 +54,11 @@ func FromMap(opts map[string]string) (Builder, []Option) {
 				case "double":
 					tableOpts = append(tableOpts, WithLineStyle(UnicodeDoubleLineStyle()))
 				}
+			case "unicode-compact":
+				tableOpts = append(tableOpts, WithLineStyle(UnicodeCompactLineStyle()))
+			case "unicode-inline":
+				tableOpts = append(tableOpts, WithLineStyle(UnicodeLineStyle()))
+				tableOpts = append(tableOpts, WithInline(true))
 			}
 		}
 		return NewTableEncoder, tableOpts

--- a/style.go
+++ b/style.go
@@ -131,3 +131,27 @@ func UnicodeDoubleLineStyle() LineStyle {
 		End:  [4]rune{'╚', '═', '╩', '╝'},
 	}
 }
+
+// UnicodeCompactLineStyle is the Unicode compact line style for tables.
+//
+// Tables using this style will look like the following:
+//
+//    ┌─────────┬──────────────────────┬─┐
+//    │author_id│name                  │z│
+//    ├─────────┼──────────────────────┼─┤
+//    │       14│a    b       c       d│x│
+//    │       15│aoeu                  │ │
+//    │         │test                  │ │
+//    │         │                      │ │
+//    └─────────┴──────────────────────┴─┘
+//
+func UnicodeCompactLineStyle() LineStyle {
+	return LineStyle{
+		// left char sep right
+		Top:  [4]rune{'┌', '─', '┬', '┐'},
+		Mid:  [4]rune{'├', '─', '┼', '┤'},
+		Row:  [4]rune{'│', 0, '│', '│'},
+		Wrap: [4]rune{'│', '↵', '│', '│'},
+		End:  [4]rune{'└', '─', '┴', '┘'},
+	}
+}

--- a/style_test.go
+++ b/style_test.go
@@ -7,22 +7,32 @@ import (
 )
 
 func TestFormats(t *testing.T) {
-	for _, n := range []string{
-		"unaligned",
-		"aligned",
+	for _, n := range []map[string]string{
+		map[string]string{"format": "unaligned"},
 		//"wrapped",
 		//"html",
 		//"asciidoc",
 		//"latex",
 		//"latex-longtable",
 		//"troff-ms",
-		"json",
-		"csv",
+		map[string]string{"format": "json"},
+		map[string]string{"format": "csv"},
+		map[string]string{"format": "aligned"},
+		map[string]string{"format": "aligned", "border": "2",
+			"linestyle": "unicode", "unicode_border_linestyle": "single"},
+		map[string]string{"format": "aligned", "border": "2",
+			"linestyle": "unicode-compact"},
+		map[string]string{"format": "aligned", "border": "1",
+			"linestyle": "unicode-compact"},
+		map[string]string{"format": "aligned", "border": "1",
+			"linestyle": "unicode", "unicode_border_linestyle": "double"},
+		map[string]string{"format": "aligned", "border": "2",
+			"linestyle": "unicode-inline"},
+		map[string]string{"format": "aligned", "border": "1",
+			"linestyle": "unicode-inline"},
 	} {
 		buf := new(bytes.Buffer)
-		if err := EncodeAll(buf, rs(), map[string]string{
-			"format": n,
-		}); err != nil {
+		if err := EncodeAll(buf, rs(), n); err != nil {
 			t.Fatalf("expected no error when encoding format %q, got: %v", n, err)
 		}
 		log.Printf("format %q:\n%s", n, buf.String())


### PR DESCRIPTION
2 new linestyles are added: unicode-compact, and unicode-inline.
All borders are now determined by calling enc.getBorders.