### PR TITLE
fix simple values' width computation

### DIFF
--- a/fmt.go
+++ b/fmt.go
@@ -450,9 +450,14 @@ func (v *Value) LineWidth(l, offset, tab int) int {
 // contained in Buf, relative to starting offset and the tab width.
 func (v *Value) MaxWidth(offset, tab int) int {
 	var width int
+
+	// simple values do not have tabulations
+	width = v.Width
+
 	for l := 0; l < len(v.Tabs); l++ {
 		width = max(width, v.LineWidth(l, offset, tab))
 	}
+
 	return width
 }
 


### PR DESCRIPTION
Simple values created with "newValue" have no tabs.
Hence maxWidth, which loops through tabs, did not calculate their width.
This fixes.