### PR TITLE
fix simple values' width computation

### DIFF
--- a/fmt.go
+++ b/fmt.go
@@ -449,10 +449,13 @@ func (v *Value) LineWidth(l, offset, tab int) int {
 // MaxWidth calculates the maximum width (in runes) of the longest line
 // contained in Buf, relative to starting offset and the tab width.
 func (v *Value) MaxWidth(offset, tab int) int {
-	var width int
+	// simple values do not have tabulations
+	width := v.Width
+
 	for l := 0; l < len(v.Tabs); l++ {
 		width = max(width, v.LineWidth(l, offset, tab))
 	}
+
 	return width
 }
 


### PR DESCRIPTION
Fixes cell width computations for values created with newValue.
maxWidth iterates through the list of tabs to get widths.
newValue does not create the v.Tabs table.