### PR TITLE
fix size of tmp buffer in FormatBytes.

### DIFF
--- a/fmt.go
+++ b/fmt.go
@@ -289,7 +289,7 @@ func FormatBytes(src []byte, invalid []byte, invalidWidth int, esc bool) *Value 
 		Tabs: make([][][2]int, 1),
 	}
 
-	var tmp [utf8.MaxRune]byte
+	var tmp [4]byte
 
 	var r rune
 	var l, w int


### PR DESCRIPTION
profiling determined that most of the time is spent allocating tmp.
However EncodeRune's max output size is 4 bytes, not utf8.MaxRune (1114111) bytes.

In a typical test case, divides exec time by 10.