### PR TITLE
add expanded table encoder

### DIFF
--- a/opts.go
+++ b/opts.go
@@ -56,7 +56,16 @@ func FromMap(opts map[string]string) (Builder, []Option) {
 				}
 			}
 		}
-		return NewTableEncoder, tableOpts
+		builder := NewTableEncoder
+		if e, ok := opts["expanded"]; ok {
+			switch e {
+			case "auto":
+				fallthrough
+			case "on":
+				builder = NewExpandedEncoder
+			}
+		}
+		return builder, tableOpts
 
 	default:
 		return newErrEncoder, []Option{withError(ErrInvalidFormat)}
@@ -69,6 +78,8 @@ func WithCount(count int) Option {
 		switch enc := v.(type) {
 		case *TableEncoder:
 			enc.count = count
+		case *ExpandedEncoder:
+			enc.count = count
 		}
 		return nil
 	}
@@ -80,6 +91,8 @@ func WithLineStyle(lineStyle LineStyle) Option {
 		switch enc := v.(type) {
 		case *TableEncoder:
 			enc.lineStyle = lineStyle
+		case *ExpandedEncoder:
+			enc.lineStyle = lineStyle
 		}
 		return nil
 	}
@@ -90,6 +103,8 @@ func WithFormatter(formatter Formatter) Option {
 	return func(v interface{}) error {
 		switch enc := v.(type) {
 		case *TableEncoder:
+			enc.formatter = formatter
+		case *ExpandedEncoder:
 			enc.formatter = formatter
 		}
 		return nil
@@ -146,6 +161,13 @@ func WithEmpty(empty string) Option {
 				return err
 			}
 			enc.empty = v[0]
+		case *ExpandedEncoder:
+			cell := interface{}(empty)
+			v, err := enc.formatter.Format([]interface{}{&cell})
+			if err != nil {
+				return err
+			}
+			enc.empty = v[0]
 		}
 		return nil
 	}
@@ -157,6 +179,8 @@ func WithWidths(widths []int) Option {
 		switch enc := v.(type) {
 		case *TableEncoder:
 			enc.widths = widths
+		case *ExpandedEncoder:
+			enc.widths = widths
 		}
 		return nil
 	}
@@ -167,6 +191,8 @@ func WithNewline(newline string) Option {
 	return func(v interface{}) error {
 		switch enc := v.(type) {
 		case *TableEncoder:
+			enc.newline = []byte(newline)
+		case *ExpandedEncoder:
 			enc.newline = []byte(newline)
 		case *JSONEncoder:
 			enc.newline = []byte(newline)
@@ -195,6 +221,8 @@ func WithBorder(border int) Option {
 	return func(v interface{}) error {
 		switch enc := v.(type) {
 		case *TableEncoder:
+			enc.border = border
+		case *ExpandedEncoder:
 			enc.border = border
 		}
 		return nil

--- a/opts_test.go
+++ b/opts_test.go
@@ -1,0 +1,48 @@
+package tblfmt
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFromMap(t *testing.T) {
+	tests := map[string]struct {
+		name       string
+		opts       map[string]string
+		expBuilder Builder
+	}{
+		"empty": {
+			expBuilder: newErrEncoder,
+		},
+		"default format": {
+			opts: map[string]string{
+				"format": "aligned",
+			},
+			expBuilder: NewTableEncoder,
+		},
+		"csv format": {
+			opts: map[string]string{
+				"format": "csv",
+			},
+			expBuilder: NewCSVEncoder,
+		},
+		"all": {
+			opts: map[string]string{
+				"format":   "aligned",
+				"border":   "2",
+				"title":    "some title",
+				"expanded": "on",
+			},
+			expBuilder: NewExpandedEncoder,
+		},
+	}
+
+	for n, test := range tests {
+		t.Run(n, func(t *testing.T) {
+			builder, _ := FromMap(test.opts)
+			if reflect.ValueOf(builder).Pointer() != reflect.ValueOf(test.expBuilder).Pointer() {
+				t.Errorf("invalid builder, expected %+v, got %+v", test.expBuilder, builder)
+			}
+		})
+	}
+}

--- a/tblfmt.go
+++ b/tblfmt.go
@@ -63,6 +63,26 @@ func EncodeTableAll(w io.Writer, resultSet ResultSet, opts ...Option) error {
 	return enc.EncodeAll(w)
 }
 
+// EncodeExpanded encodes result set to the writer as a table using the supplied
+// encoding options.
+func EncodeExpanded(w io.Writer, resultSet ResultSet, opts ...Option) error {
+	enc, err := NewExpandedEncoder(resultSet, opts...)
+	if err != nil {
+		return err
+	}
+	return enc.Encode(w)
+}
+
+// EncodeExpandedAll encodes all result sets to the writer as a table using the
+// supplied encoding options.
+func EncodeExpandedAll(w io.Writer, resultSet ResultSet, opts ...Option) error {
+	enc, err := NewExpandedEncoder(resultSet, opts...)
+	if err != nil {
+		return err
+	}
+	return enc.EncodeAll(w)
+}
+
 // EncodeJSON encodes the result set to the writer as JSON using the supplied
 // encoding options.
 func EncodeJSON(w io.Writer, resultSet ResultSet, opts ...Option) error {

--- a/tblfmt_test.go
+++ b/tblfmt_test.go
@@ -18,6 +18,9 @@ func TestEncodeFormats(t *testing.T) {
 		"aligned,border 0,title 'test title'",
 		"aligned,border 1,title 'test title'",
 		"aligned,border 2,title 'test title'",
+		"aligned,border 0,expanded on",
+		"aligned,border 1,expanded on",
+		"aligned,border 2,expanded on",
 		//"wrapped",
 		//"html",
 		//"asciidoc",
@@ -62,6 +65,20 @@ func TestEncodeFormats(t *testing.T) {
 			t.Log("\n", newlineRE.ReplaceAllString(buf.String(), "\t"))
 		})
 	}
+}
+
+func TestTinyAligned(t *testing.T) {
+	resultSet := rstiny()
+	buf := new(bytes.Buffer)
+	params := map[string]string{
+		"format":   "aligned",
+		"expanded": "on",
+		"border":   "2",
+	}
+	if err := EncodeAll(buf, resultSet, params); err != nil {
+		t.Fatalf("expected no error when encoding, got: %v", err)
+	}
+	t.Log("\n", newlineRE.ReplaceAllString(buf.String(), "\t"))
 }
 
 func TestBigAligned(t *testing.T) {

--- a/util_test.go
+++ b/util_test.go
@@ -134,6 +134,17 @@ func rsbig() *rset {
 	}
 }
 
+func rstiny() *rset {
+	return &rset{
+		cols: []string{"z"},
+		vals: [][][]interface{}{
+			{
+				{"x"},
+			},
+		},
+	}
+}
+
 // rsset returns a predefined set of records for rs.
 func rsset(i int) [][]interface{} {
 	return [][]interface{}{
@@ -275,7 +286,7 @@ func psqlEncode(w io.Writer, resultSet ResultSet, params map[string]string, dsn 
 	// exec
 	stdout := new(bytes.Buffer)
 	q := fmt.Sprintf(psqlValuesQuery, pset, vals)
-	cmd := exec.Command("psql", dsn, "-q")
+	cmd := exec.Command("psql", dsn, "-qX")
 	cmd.Stdin, cmd.Stdout = bytes.NewReader([]byte(q)), stdout
 	if err = cmd.Run(); err != nil {
 		return err


### PR DESCRIPTION
Add expanded table encoder,  based on the existing table encoder. Recognizes "auto" but treats this as "on".

It ignores some inherited options but this is an existing issue where some `With*` functions would silently fail if they don't match the type.