### PR TITLE
allow to skip drawing the summary/footer

### DIFF
--- a/opts.go
+++ b/opts.go
@@ -41,6 +41,12 @@ func FromMap(opts map[string]string) (Builder, []Option) {
 			border, _ := strconv.Atoi(s)
 			tableOpts = append(tableOpts, WithBorder(border))
 		}
+		if s, ok := opts["footer"]; ok {
+			if s == "off" {
+				// use an empty summary map to skip drawing the footer
+				tableOpts = append(tableOpts, WithSummary(map[int]func(io.Writer, int) (int, error){}))
+			}
+		}
 		if s, ok := opts["linestyle"]; ok {
 			switch s {
 			case "ascii":

--- a/tblfmt_test.go
+++ b/tblfmt_test.go
@@ -18,6 +18,7 @@ func TestEncodeFormats(t *testing.T) {
 		"aligned,border 0,title 'test title'",
 		"aligned,border 1,title 'test title'",
 		"aligned,border 2,title 'test title'",
+		"aligned,footer off",
 		//"wrapped",
 		//"html",
 		//"asciidoc",


### PR DESCRIPTION
Allow to skip drawing the summary/footer if a `footer=off` option is passed. This should match psql, there's a `footer` var described in the manual in the `\pset` section.