### PR TITLE
expanded table encoder and optional summary/footer

### DIFF
--- a/opts.go
+++ b/opts.go
@@ -41,6 +41,12 @@ func FromMap(opts map[string]string) (Builder, []Option) {
 			border, _ := strconv.Atoi(s)
 			tableOpts = append(tableOpts, WithBorder(border))
 		}
+		if s, ok := opts["footer"]; ok {
+			if s == "off" {
+				// use an empty summary map to skip drawing the footer
+				tableOpts = append(tableOpts, WithSummary(map[int]func(io.Writer, int) (int, error){}))
+			}
+		}
 		if s, ok := opts["linestyle"]; ok {
 			switch s {
 			case "ascii":

--- a/opts_test.go
+++ b/opts_test.go
@@ -1,0 +1,48 @@
+package tblfmt
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFromMap(t *testing.T) {
+	tests := map[string]struct {
+		name       string
+		opts       map[string]string
+		expBuilder Builder
+	}{
+		"empty": {
+			expBuilder: newErrEncoder,
+		},
+		"default format": {
+			opts: map[string]string{
+				"format": "aligned",
+			},
+			expBuilder: NewTableEncoder,
+		},
+		"csv format": {
+			opts: map[string]string{
+				"format": "csv",
+			},
+			expBuilder: NewCSVEncoder,
+		},
+		"all": {
+			opts: map[string]string{
+				"format":   "aligned",
+				"border":   "2",
+				"title":    "some title",
+				"expanded": "on",
+			},
+			expBuilder: NewExpandedEncoder,
+		},
+	}
+
+	for n, test := range tests {
+		t.Run(n, func(t *testing.T) {
+			builder, _ := FromMap(test.opts)
+			if reflect.ValueOf(builder).Pointer() != reflect.ValueOf(test.expBuilder).Pointer() {
+				t.Errorf("invalid builder, expected %+v, got %+v", test.expBuilder, builder)
+			}
+		})
+	}
+}

--- a/tblfmt.go
+++ b/tblfmt.go
@@ -63,6 +63,26 @@ func EncodeTableAll(w io.Writer, resultSet ResultSet, opts ...Option) error {
 	return enc.EncodeAll(w)
 }
 
+// EncodeExpanded encodes result set to the writer as a table using the supplied
+// encoding options.
+func EncodeExpanded(w io.Writer, resultSet ResultSet, opts ...Option) error {
+	enc, err := NewExpandedEncoder(resultSet, opts...)
+	if err != nil {
+		return err
+	}
+	return enc.Encode(w)
+}
+
+// EncodeExpandedAll encodes all result sets to the writer as a table using the
+// supplied encoding options.
+func EncodeExpandedAll(w io.Writer, resultSet ResultSet, opts ...Option) error {
+	enc, err := NewExpandedEncoder(resultSet, opts...)
+	if err != nil {
+		return err
+	}
+	return enc.EncodeAll(w)
+}
+
 // EncodeJSON encodes the result set to the writer as JSON using the supplied
 // encoding options.
 func EncodeJSON(w io.Writer, resultSet ResultSet, opts ...Option) error {

--- a/tblfmt_test.go
+++ b/tblfmt_test.go
@@ -18,6 +18,7 @@ func TestEncodeFormats(t *testing.T) {
 		"aligned,border 0,title 'test title'",
 		"aligned,border 1,title 'test title'",
 		"aligned,border 2,title 'test title'",
+		"aligned,footer off",
 		//"wrapped",
 		//"html",
 		//"asciidoc",

--- a/tblfmt_test.go
+++ b/tblfmt_test.go
@@ -19,6 +19,9 @@ func TestEncodeFormats(t *testing.T) {
 		"aligned,border 1,title 'test title'",
 		"aligned,border 2,title 'test title'",
 		"aligned,footer off",
+		"aligned,border 0,expanded on",
+		"aligned,border 1,expanded on",
+		"aligned,border 2,expanded on",
 		//"wrapped",
 		//"html",
 		//"asciidoc",
@@ -63,6 +66,20 @@ func TestEncodeFormats(t *testing.T) {
 			t.Log("\n", newlineRE.ReplaceAllString(buf.String(), "\t"))
 		})
 	}
+}
+
+func TestTinyAligned(t *testing.T) {
+	resultSet := rstiny()
+	buf := new(bytes.Buffer)
+	params := map[string]string{
+		"format":   "aligned",
+		"expanded": "on",
+		"border":   "2",
+	}
+	if err := EncodeAll(buf, resultSet, params); err != nil {
+		t.Fatalf("expected no error when encoding, got: %v", err)
+	}
+	t.Log("\n", newlineRE.ReplaceAllString(buf.String(), "\t"))
 }
 
 func TestBigAligned(t *testing.T) {

--- a/util_test.go
+++ b/util_test.go
@@ -134,6 +134,17 @@ func rsbig() *rset {
 	}
 }
 
+func rstiny() *rset {
+	return &rset{
+		cols: []string{"z"},
+		vals: [][][]interface{}{
+			{
+				{"x"},
+			},
+		},
+	}
+}
+
 // rsset returns a predefined set of records for rs.
 func rsset(i int) [][]interface{} {
 	return [][]interface{}{
@@ -275,7 +286,7 @@ func psqlEncode(w io.Writer, resultSet ResultSet, params map[string]string, dsn 
 	// exec
 	stdout := new(bytes.Buffer)
 	q := fmt.Sprintf(psqlValuesQuery, pset, vals)
-	cmd := exec.Command("psql", dsn, "-q")
+	cmd := exec.Command("psql", dsn, "-qX")
 	cmd.Stdin, cmd.Stdout = bytes.NewReader([]byte(q)), stdout
 	if err = cmd.Run(); err != nil {
 		return err


### PR DESCRIPTION
Add expanded table encoder, based on the existing table encoder. Recognizes "auto" but treats this as "on".

It ignores some inherited options but this is an existing issue where some With* functions would silently fail if they don't match the type.

Allow to skip drawing the summary/footer if a footer=off option is passed. This should match psql, there's a footer var described in the manual in the \pset section.

Combines #9 and #8