### PR TITLE
Auto expand if width is greater than screen

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/xo/tblfmt
 
-require github.com/mattn/go-runewidth v0.0.9
+require (
+	github.com/mattn/go-runewidth v0.0.9
+	github.com/nathan-fiscaletti/consolesize-go v0.0.0-20210105204122-a87d9f614b9d
+)
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/nathan-fiscaletti/consolesize-go v0.0.0-20210105204122-a87d9f614b9d h1:PQW4Aqovdqc9efHl9EVA+bhKmuZ4ME1HvSYYDvaDiK0=
+github.com/nathan-fiscaletti/consolesize-go v0.0.0-20210105204122-a87d9f614b9d/go.mod h1:cxIIfNMTwff8f/ZvRouvWYF6wOoO7nj99neWSx2q/Es=

--- a/tblfmt_test.go
+++ b/tblfmt_test.go
@@ -235,6 +235,20 @@ func TestTinyAligned(t *testing.T) {
 	}
 }
 
+func TestWideExpanded(t *testing.T) {
+	resultSet := rswide()
+	buf := new(bytes.Buffer)
+	params := map[string]string{
+		"format":   "aligned",
+		"expanded": "auto",
+		"border":   "2",
+	}
+	if err := EncodeAll(buf, resultSet, params); err != nil {
+		t.Fatalf("expected no error when encoding, got: %v", err)
+	}
+	t.Log("\n", newlineRE.ReplaceAllString(buf.String(), "\t"))
+}
+
 func TestBigAligned(t *testing.T) {
 	resultSet := rsbig()
 

--- a/util_test.go
+++ b/util_test.go
@@ -150,6 +150,28 @@ func rstiny() *rset {
 	}
 }
 
+func rswide() *rset {
+	return &rset{
+		cols: []string{
+			"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			"cccccccccccccccccccccccccccccc",
+			"dddddddddddddddddddddddddddddd",
+			"eeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+			"ffffffffffffffffffffffffffffff",
+			"gggggggggggggggggggggggggggggg",
+			"hhhhhhhhhhhhhhhhhhhhhhhhhhhhhh",
+			"iiiiiiiiiiiiiiiiiiiiiiiiiiiiii",
+			"jjjjjjjjjjjjjjjjjjjjjjjjjjjjjj",
+		},
+		vals: [][][]interface{}{
+			{
+				{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"},
+			},
+		},
+	}
+}
+
 // rsset returns a predefined set of records for rs.
 func rsset(i int) [][]interface{} {
 	return [][]interface{}{


### PR DESCRIPTION
Use the expanded encoder if the table width is greater than the screen. If fetching screen size fails (not a tty) it should return 0 and be ignored.

I had to move the divider into the loop to properly terminate the current set before drawing another.

I also added the `summary()` to the expanded encoder. I skipped that in #8 to avoid drawing the number of records since every record is numbered already and the last one contains the same info. This matches `psql`. But it'll prevent drawing _any_ extra footers.

I couldn't figure out how to write a test. It seems that tests don't have a TTY (kinda makes sense). I tested this manually by copying the tiny test into a runnable command but I'm not sure I should include it.

Fixes https://github.com/xo/usql/issues/168

BTW reading screen size will be required for adding pager support.