### PR TITLE
Implement template encoder

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -32,3 +32,35 @@ func TestJSONEncoder(t *testing.T) {
 		i++
 	}
 }
+
+func TestTemplateEncoder(t *testing.T) {
+	expected := `
+Row 0:
+  author_id = "15"
+  name = "aoeu
+test
+"
+  z = ""
+
+Row 1:
+  author_id = "15"
+  name = "aoeu
+test
+"
+  z = ""
+
+`
+	template := `
+{{ range $i, $r := .Rows }}Row {{ $i }}:
+{{ range . }}  {{ .Name }} = "{{ .Value }}"
+{{ end }}
+{{ end }}`
+	buf := new(bytes.Buffer)
+	if err := EncodeTemplateAll(buf, rs(), WithTextTemplate(template)); err != nil {
+		t.Fatalf("expected no error when Template encoding, got: %v", err)
+	}
+	actual := buf.String()
+	if actual != expected {
+		t.Fatalf("expected encoder to return:\n-- expected --\n%v\n-- end --\n\nbut got:\n-- encoded --\n%s\n-- end --", expected, actual)
+	}
+}

--- a/fmt.go
+++ b/fmt.go
@@ -435,6 +435,10 @@ type Value struct {
 	Raw bool
 }
 
+func (v Value) String() string {
+	return string(v.Buf)
+}
+
 // LineWidth returns the line width (in runes) of line l.
 func (v *Value) LineWidth(l, offset, tab int) int {
 	var width int

--- a/templates.go
+++ b/templates.go
@@ -1,0 +1,41 @@
+package tblfmt
+
+import html "html/template"
+
+var (
+	templates = map[string]string{
+		"html": `
+<table {{.Attributes | attr}}>
+	<caption>{{.Title}}</caption>
+	<thead>
+		<tr>
+{{range .Headers}}			<th align="{{.Align}}">{{.}}</th>
+{{end}}
+		</tr>
+	</thead>
+	<tbody>
+{{range .Rows}}		<tr>
+{{range .}}			<td align="{{.Value.Align}}">{{.Value}}</td>
+{{end}}		</tr>
+{{end}}
+	</tbody>
+</table>`,
+		"asciidoc": `
+[%header]
+{{if .Title.Buf}}.{{.Title}}
+{{end}}|===
+{{range .Headers}}|{{.}}
+{{end}}
+{{range .Rows}}{{range .}}|{{.Value}}
+{{end}}
+{{end}}|===`,
+	}
+	htmlFuncMap = html.FuncMap{
+		"attr": func(s string) html.HTMLAttr {
+			return html.HTMLAttr(s)
+		},
+		"safe": func(s string) html.HTML {
+			return html.HTML(s)
+		},
+	}
+)

--- a/util.go
+++ b/util.go
@@ -41,6 +41,9 @@ const (
 
 	// ErrInvalidLineStyle is the invalid line style error.
 	ErrInvalidLineStyle Error = "invalid line style"
+
+	// ErrUnknownTemplate is the unknown template error.
+	ErrUnknownTemplate Error = "unknown template"
 )
 
 // errEncoder provides a no-op encoder that always returns the wrapped error.


### PR DESCRIPTION
`html/template` is used for html tables, `text/template` for all other custom formats.

This resolves https://github.com/xo/usql/issues/139 and https://github.com/xo/usql/issues/140