### PR TITLE
Pager support

### DIFF
--- a/opts.go
+++ b/opts.go
@@ -76,7 +76,15 @@ func FromMap(opts map[string]string) (Builder, []Option) {
 		if e, ok := opts["expanded"]; ok {
 			switch e {
 			case "auto":
-				cols, _ := consolesize.GetConsoleSize()
+				cols := 0
+				if cstr, ok := opts["columns"]; ok && cstr != "" {
+					if c, err := strconv.ParseUint(cstr, 10, 32); err == nil {
+						cols = int(c)
+					}
+				}
+				if cols == 0 {
+					cols, _ = consolesize.GetConsoleSize()
+				}
 				tableOpts = append(tableOpts, WithMaxWidth(cols))
 			case "on":
 				builder = NewExpandedEncoder


### PR DESCRIPTION
Recognize new options:
* `pager` - `on` checks if output width and height exceeds values from `columns` and `pager_min_lines`, or current terminal size, if these are not set (or zero); `always` makes it always redirect output to pager
* `pager_cmd` - this is the name of the pager command

Since I added `columns` support for pager, it also makes sense to use it for the expanded mode.

Note that `psql` runs the pager using `popen`, which wraps the command in `sh -c <cmd>`. I did not add that here.

There's one issue I haven't resolved - when the pager exits without consuming whole input (press `q` right after `less` is opened, without scrolling), a `broken pipe` error is returned by tblfmt. I'm not sure how to reliably detect this. Maybe it's ok to just check if error message contains `broken pipe`.

Related to https://github.com/xo/usql/issues/155