### PR TITLE
Don't ignore statement errors

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -302,7 +302,7 @@ func (enc *TableEncoder) nextResults() ([][]*Value, error) {
 			break
 		}
 	}
-	return vals, nil
+	return vals, enc.resultSet.Err()
 }
 
 func (enc *TableEncoder) calcWidth(vals [][]*Value) {
@@ -935,6 +935,10 @@ func (enc *JSONEncoder) Encode(w io.Writer) error {
 			return err
 		}
 	}
+	err = enc.resultSet.Err()
+	if err != nil {
+		return err
+	}
 	// end
 	_, err = w.Write(end)
 	return err
@@ -1109,7 +1113,7 @@ func (enc *UnalignedEncoder) Encode(w io.Writer) error {
 			return err
 		}
 	}
-	return nil
+	return enc.resultSet.Err()
 }
 
 // EncodeAll encodes all result sets to the writer using the encoder settings.


### PR DESCRIPTION
I was querying the Trino server using a data type that's not supported by the driver and was surprised that I got zero rows instead of an error. So I implemented the missing bits in the driver, but it would also be nice if `tblfmt` didn't ignore errors :-)