### PR TITLE
support `jsonl` encoder option

### DIFF
--- a/fmt.go
+++ b/fmt.go
@@ -12,7 +12,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	runewidth "github.com/mattn/go-runewidth"
+	"github.com/mattn/go-runewidth"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 	"golang.org/x/text/number"
@@ -519,6 +519,16 @@ func WithEncoder(encoder func(interface{}) ([]byte, error)) EscapeFormatterOptio
 func WithIsJSON(isJSON bool) EscapeFormatterOption {
 	return func(f *EscapeFormatter) {
 		f.isJSON = isJSON
+	}
+}
+
+// WithIsJSONL is an escape formatter option to enable special escaping for JSONL
+// characters in non-complex values.
+func WithIsJSONL(isJSONL bool) EscapeFormatterOption {
+	return func(f *EscapeFormatter) {
+		f.isJSON = isJSONL
+		f.prefix = ""
+		f.indent = ""
 	}
 }
 

--- a/opts.go
+++ b/opts.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/nathan-fiscaletti/consolesize-go"
+
 	"github.com/xo/tblfmt/templates"
 )
 
@@ -95,6 +96,12 @@ func FromMap(opts map[string]string) (Builder, []Option) {
 	switch format := opts["format"]; format {
 	case "json":
 		return NewJSONEncoder, []Option{
+			WithLowerColumnNames(opts["lower_column_names"] == "true"),
+			WithUseColumnTypes(opts["use_column_types"] == "true"),
+			WithFormatterOptions(WithTimeFormat(timeFormat)),
+		}
+	case "jsonl":
+		return NewJSONLEncoder, []Option{
 			WithLowerColumnNames(opts["lower_column_names"] == "true"),
 			WithUseColumnTypes(opts["use_column_types"] == "true"),
 			WithFormatterOptions(WithTimeFormat(timeFormat)),

--- a/tblfmt.go
+++ b/tblfmt.go
@@ -103,6 +103,26 @@ func EncodeJSONAll(w io.Writer, resultSet ResultSet, opts ...Option) error {
 	return enc.EncodeAll(w)
 }
 
+// EncodeJSONL encodes the result set to the writer as JSON-line using the supplied
+// encoding options.
+func EncodeJSONL(w io.Writer, resultSet ResultSet, opts ...Option) error {
+	enc, err := NewJSONLEncoder(resultSet, opts...)
+	if err != nil {
+		return err
+	}
+	return enc.Encode(w)
+}
+
+// EncodeJSONLAll encodes all result sets to the writer as JSON-line using the
+// supplied encoding options.
+func EncodeJSONLAll(w io.Writer, resultSet ResultSet, opts ...Option) error {
+	enc, err := NewJSONLEncoder(resultSet, opts...)
+	if err != nil {
+		return err
+	}
+	return enc.EncodeAll(w)
+}
+
 // EncodeUnaligned encodes the result set to the writer unaligned using the
 // supplied encoding options.
 func EncodeUnaligned(w io.Writer, resultSet ResultSet, opts ...Option) error {

--- a/tblfmt_test.go
+++ b/tblfmt_test.go
@@ -104,6 +104,35 @@ func TestEncodeJSONAll(t *testing.T) {
 	}
 }
 
+func TestEncodeJSONLAll(t *testing.T) {
+	t.Parallel()
+	exp := `{"author_id":14,"name":"a\tb\tc\td","z":"x"}
+{"author_id":15,"name":"aoeu\ntest\n","z":null}
+{"author_id":16,"name":"foo\bbar","z":null}
+{"author_id":17,"name":"袈\t袈\t\t袈","z":null}
+{"author_id":18,"name":"a\tb\t\r\n\ta","z":"a\n"}
+{"author_id":19,"name":"袈\t袈\t\t袈\n","z":null}
+{"author_id":20,"name":"javascript","z":{"test21":"a value","test22":"foo\u0008bar"}}
+{"author_id":23,"name":"slice","z":["a","b"]}
+{"author_id":38,"name":"a\tb\tc\td","z":"x"}
+{"author_id":39,"name":"aoeu\ntest\n","z":null}
+{"author_id":40,"name":"foo\bbar","z":null}
+{"author_id":41,"name":"袈\t袈\t\t袈","z":null}
+{"author_id":42,"name":"a\tb\t\r\n\ta","z":"a\n"}
+{"author_id":43,"name":"袈\t袈\t\t袈\n","z":null}
+{"author_id":44,"name":"javascript","z":{"test45":"a value","test46":"foo\u0008bar"}}
+{"author_id":47,"name":"slice","z":["a","b"]}
+`
+	buf := new(bytes.Buffer)
+	if err := EncodeJSONLAll(buf, internal.NewRsetMulti()); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	actual := buf.String()
+	if actual != exp {
+		t.Errorf("expected:\n%q\n---\ngot:\n%q", exp, actual)
+	}
+}
+
 func TestEncodeTemplateAll(t *testing.T) {
 	t.Parallel()
 	exp := `Row 0:


### PR DESCRIPTION
To support jsonl in [usql](https://github.com/xo/usql), we added support for jsonl format to tblfmt.